### PR TITLE
Fix 9 rows limit bug in Generate form

### DIFF
--- a/RandomValuesNppPlugin/Forms/GenerateForm.cs
+++ b/RandomValuesNppPlugin/Forms/GenerateForm.cs
@@ -35,7 +35,7 @@ namespace RandomValuesNppPlugin
             //};
 
             listRandomValues = new List<RandomValueListItem>();
-            for (var i = 1; i < 10; i++)
+            for (var i = 1; i <= 10; i++)
             {
                 String def = "";
 
@@ -234,7 +234,7 @@ namespace RandomValuesNppPlugin
             Main.settings.GenerateType = cmbOutputType.SelectedIndex;
             Main.settings.GenerateAmount = Convert.ToInt32(numAmount.Value);
 
-            for (var i = 1; i < 10; i++)
+            for (var i = 1; i <= 10; i++)
             {
                 var def = "";
                 if (i <= listRandomValues.Count)

--- a/RandomValuesNppPlugin/Forms/GenerateForm.cs
+++ b/RandomValuesNppPlugin/Forms/GenerateForm.cs
@@ -118,6 +118,9 @@ namespace RandomValuesNppPlugin
 
         private void menuitemAddRow_Click(object sender, EventArgs e)
         {
+            // Prevent users from adding more than the ten supported rows
+            if (listRandomValues.Count >= 10) return
+            
             // add random example
             string[] examples = new string[] {
                 "Password|String|XXXXYYYYZZZZ9999||case=mixed,mixmask=true,pwsafe=true",


### PR DESCRIPTION
The generate form ignores the 10th rows on saving the settings and generating the random values. The reason are two bugs in  the file [RandomValuesNppPlugin/Forms/GenerateForm.cs](https://github.com/BdR76/RandomValuesNPP/blob/a38b628b1af568dabb903368ec3f3ae76eb6522f/RandomValuesNppPlugin/Forms/GenerateForm.cs) where the for loops only count till 9 instead of 10.

This PR fixes the bug(s).

Fixes issue: #7

**⚠ Note: I didn't compile an test the code!!**